### PR TITLE
refactor: avoid innerHTML for quota rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,7 +428,7 @@
 
             // 기타 할당량 표시
             const otherQuotasContainer = document.getElementById('other-quotas');
-            otherQuotasContainer.innerHTML = '';
+            otherQuotasContainer.replaceChildren();
             
             Object.entries(data.quota_snapshots)
                 .filter(([key]) => key !== 'premium_interactions')
@@ -459,61 +459,124 @@
 
         // 기타 할당량 요소 생성
         function createQuotaElement(quota) {
-            const div = document.createElement('div');
-            div.className = 'space-y-2 p-3 bg-gray-50 rounded-lg';
-            
-            const iconSvg = getQuotaIconSvg(quota.quota_id);
-            const colorClass = getQuotaColor(quota.percent_remaining);
-            
-            div.innerHTML = `
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        ${iconSvg}
-                        <span class="font-medium capitalize text-sm">
-                            ${quota.quota_id.replace('_', ' ')}
-                        </span>
-                        ${quota.unlimited ? '<span class="text-xs border border-gray-300 text-gray-700 px-2 py-1 rounded-md">무제한</span>' : ''}
-                    </div>
-                    <div class="text-right">
-                        ${quota.unlimited ? 
-                            '<span class="text-sm text-green-600 font-medium">무제한</span>' :
-                            `<div class="space-y-1">
-                                <div class="text-sm font-medium">
-                                    <span class="${colorClass}">
-                                        ${quota.remaining} / ${quota.entitlement}
-                                    </span>
-                                </div>
-                                <div class="text-xs text-gray-500">${quota.percent_remaining.toFixed(1)}% 남음</div>
-                            </div>`
-                        }
-                    </div>
-                </div>
-                ${!quota.unlimited ? `
-                    <div class="space-y-1">
-                        <div class="progress-bar h-2">
-                            <div class="progress-fill-default" style="width: ${quota.percent_remaining}%"></div>
-                        </div>
-                        <div class="flex justify-between text-xs text-gray-500">
-                            <span>사용량: ${quota.entitlement - quota.remaining}</span>
-                            <span class="hidden sm:inline">
-                                초과 허용: ${quota.overage_permitted ? '예' : '아니오'}
-                            </span>
-                        </div>
-                    </div>
-                ` : ''}
-            `;
-            
-            return div;
+            const container = document.createElement('div');
+            container.className = 'space-y-2 p-3 bg-gray-50 rounded-lg';
+
+            const topRow = document.createElement('div');
+            topRow.className = 'flex items-center justify-between';
+            container.appendChild(topRow);
+
+            const left = document.createElement('div');
+            left.className = 'flex items-center gap-2';
+            topRow.appendChild(left);
+
+            const icon = getQuotaIconSvg(quota.quota_id);
+            left.appendChild(icon);
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'font-medium capitalize text-sm';
+            nameSpan.textContent = quota.quota_id.replace('_', ' ');
+            left.appendChild(nameSpan);
+
+            if (quota.unlimited) {
+                const unlimitedSpan = document.createElement('span');
+                unlimitedSpan.className = 'text-xs border border-gray-300 text-gray-700 px-2 py-1 rounded-md';
+                unlimitedSpan.textContent = '무제한';
+                left.appendChild(unlimitedSpan);
+            }
+
+            const right = document.createElement('div');
+            right.className = 'text-right';
+            topRow.appendChild(right);
+
+            if (quota.unlimited) {
+                const unlimitedText = document.createElement('span');
+                unlimitedText.className = 'text-sm text-green-600 font-medium';
+                unlimitedText.textContent = '무제한';
+                right.appendChild(unlimitedText);
+            } else {
+                const rightWrapper = document.createElement('div');
+                rightWrapper.className = 'space-y-1';
+                right.appendChild(rightWrapper);
+
+                const topLine = document.createElement('div');
+                topLine.className = 'text-sm font-medium';
+                rightWrapper.appendChild(topLine);
+
+                const colorSpan = document.createElement('span');
+                colorSpan.className = getQuotaColor(quota.percent_remaining);
+                colorSpan.textContent = `${quota.remaining} / ${quota.entitlement}`;
+                topLine.appendChild(colorSpan);
+
+                const percentDiv = document.createElement('div');
+                percentDiv.className = 'text-xs text-gray-500';
+                percentDiv.textContent = `${quota.percent_remaining.toFixed(1)}% 남음`;
+                rightWrapper.appendChild(percentDiv);
+            }
+
+            if (!quota.unlimited) {
+                const bottom = document.createElement('div');
+                bottom.className = 'space-y-1';
+                container.appendChild(bottom);
+
+                const progressBar = document.createElement('div');
+                progressBar.className = 'progress-bar h-2';
+                bottom.appendChild(progressBar);
+
+                const progressFill = document.createElement('div');
+                progressFill.className = 'progress-fill-default';
+                progressFill.style.width = `${quota.percent_remaining}%`;
+                progressBar.appendChild(progressFill);
+
+                const usageDiv = document.createElement('div');
+                usageDiv.className = 'flex justify-between text-xs text-gray-500';
+                bottom.appendChild(usageDiv);
+
+                const usageSpan = document.createElement('span');
+                usageSpan.textContent = `사용량: ${quota.entitlement - quota.remaining}`;
+                usageDiv.appendChild(usageSpan);
+
+                const overageSpan = document.createElement('span');
+                overageSpan.className = 'hidden sm:inline';
+                overageSpan.textContent = `초과 허용: ${quota.overage_permitted ? '예' : '아니오'}`;
+                usageDiv.appendChild(overageSpan);
+            }
+
+            return container;
         }
 
         // 할당량 아이콘 SVG 반환
         function getQuotaIconSvg(quotaId) {
-            const iconMap = {
-                chat: '<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>',
-                completions: '<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>',
-                premium_interactions: '<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>'
-            };
-            return iconMap[quotaId] || '<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>';
+            const svgNS = 'http://www.w3.org/2000/svg';
+            const svg = document.createElementNS(svgNS, 'svg');
+            svg.setAttribute('class', 'h-4 w-4');
+            svg.setAttribute('fill', 'none');
+            svg.setAttribute('stroke', 'currentColor');
+            svg.setAttribute('viewBox', '0 0 24 24');
+
+            const path = document.createElementNS(svgNS, 'path');
+            path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('stroke-linejoin', 'round');
+            path.setAttribute('stroke-width', '2');
+
+            let d;
+            switch (quotaId) {
+                case 'chat':
+                    d = 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z';
+                    break;
+                case 'completions':
+                    d = 'M13 10V3L4 14h7v7l9-11h-7z';
+                    break;
+                case 'premium_interactions':
+                    d = 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z';
+                    break;
+                default:
+                    d = 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z';
+            }
+
+            path.setAttribute('d', d);
+            svg.appendChild(path);
+            return svg;
         }
 
         // 할당량 색상 반환


### PR DESCRIPTION
## Summary
- replace innerHTML manipulations with DOM APIs when rendering quota sections
- build quota icons using DOM elements to avoid string-based SVG injection

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68971f510e308321a9abaa13902457d1